### PR TITLE
Hack to bypass local eyetrace caching optimization to fix the sit direction arrow not functioning correctly

### DIFF
--- a/sit/lua/sitanywhere/client/sit.lua
+++ b/sit/lua/sitanywhere/client/sit.lua
@@ -9,6 +9,7 @@ local function ShouldSit(ply)
 	return hook.Run("ShouldSit", ply)
 end
 
+local traceCache = {}
 local arrow, drawScale, traceDist = Material("widgets/arrow.png"), 0.1, 20
 local traceScaled = traceDist / drawScale
 
@@ -75,6 +76,8 @@ end
 
 local function DoSit(trace)
 	if not trace.Hit then return end
+	table.CopyFromTo(trace, traceCache)
+	trace = traceCache -- awful hack!! yuck!!
 
 	local surfaceAng = trace.HitNormal:Angle() + Angle(-270, 0, 0)
 


### PR DESCRIPTION
Band-aid fixes behavior that was supposedly optimized in [https://github.com/Facepunch/garrysmod/pull/2395](url), causing the table to get redone every frame in all cases.

Default branch (version 2025.12.10) (identical with fix applied)

https://github.com/user-attachments/assets/92e0af44-c382-4443-8c0f-3de6d519a73d

x86-64 branch (version 2026.04.15)

https://github.com/user-attachments/assets/de4c5f18-e520-4dde-a8be-a58664d6b040
