### PR TITLE
Disallow duplicating seats

### DIFF
--- a/sit/lua/sitanywhere/server/sit.lua
+++ b/sit/lua/sitanywhere/server/sit.lua
@@ -117,6 +117,7 @@ local function Sit(ply, pos, ang, parent, parentbone, func, exit)
 	vehicle.ClassOverride = "prop_vehicle_prisoner_pod"
 
 	vehicle.PhysgunDisabled = true
+	vehicle.DoNotDuplicate = true
 	vehicle.m_tblToolsAllowed = {}
 	vehicle.customCheck = function() return false end -- DarkRP plz
 


### PR DESCRIPTION
If you try to copy a dupe through AdvDupe2 when a player is sitting on it, it will be copied along with this seat, which can slightly spoil it